### PR TITLE
Make factor levels unique

### DIFF
--- a/R/annotate.R
+++ b/R/annotate.R
@@ -303,7 +303,7 @@ target_disease_associations <-
                         .data$tissue_assoc_rank * 100) %>%
         dplyr::mutate(
           symbol = factor(
-            .data$symbol, levels = result$target$symbol
+            .data$symbol, levels = unique(result$target$symbol)
           )
         ) %>%
         dplyr::arrange(.data$symbol) %>%


### PR DESCRIPTION
A trivial fix for the situation when different Ensembl IDs may map to the same gene symbol, which throws an error like:
```
Error in `dplyr::mutate()`:
  ! Problem while computing `symbol = factor(.data$symbol, levels =
                                               result$target$symbol)`.
Caused by error in `levels<-`:
  ! factor level [390] is duplicated
```
Thanks, Sigve, for the great package!